### PR TITLE
Use poetry-core for builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ ufo2ft = ">=2.0.0"
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 flowify = 'flowify:main'


### PR DESCRIPTION
There have been changes to Poetry since this was put out and this no longer builds like it used to. As I understand it `poetry` the full blown tool is great for developers, but it is not meant to be used when all you need to do is build a package—as for example Linux distros need to do. For that purpose `poetry-core` handles the build machinery without dragging in extra dependencies and (as in this project) unresolvable conflicts version pinning comming from other tools.

I've had to do just this patching to keep `flowify` building on Arch Linux now that the system default Python is 3.12 and has Poetry 1.8.

Also note my last pr #1 is still not in a release, so we're still having to patch that before building too. A minor patch release would make downstream life a lot easier.
